### PR TITLE
Bugfixing incomplete PRs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jqassistant.plugin</groupId>
         <artifactId>parent</artifactId>
-        <version>2.4.0-M3</version>
+        <version>2.6.0</version>
     </parent>
 
     <artifactId>jqassistant-github-plugin</artifactId>
@@ -67,13 +67,13 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.8.3</version>
+            <version>1.19.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
 
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.314</version>
+            <version>1.326</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/jqassistant/plugin/github/scanner/GraphBuilder.java
+++ b/src/main/java/org/jqassistant/plugin/github/scanner/GraphBuilder.java
@@ -38,7 +38,7 @@ class GraphBuilder {
 
         // branch dependent
         importBranch(ghRepository, gitHubRepository, branch);
-        importPullRequests(ghRepository, gitHubRepository, branch); // first import PRs, because they'll also be returned when fetching issues
+        importPullRequests(ghRepository, gitHubRepository); // first import PRs, because they'll also be returned when fetching issues
 
         // branch independent
         importMilestones(ghRepository, gitHubRepository);
@@ -61,9 +61,9 @@ class GraphBuilder {
         }
     }
 
-    private void importPullRequests(GHRepository repository, GitHubRepository gitHubRepository, String branch) {
+    private void importPullRequests(GHRepository repository, GitHubRepository gitHubRepository) {
         List<GitHubPullRequest> pullRequests = new LinkedList<>();
-        for (GHPullRequest ghPullRequest : repository.queryPullRequests().base(branch).list()) {
+        for (GHPullRequest ghPullRequest : repository.queryPullRequests().state(GHIssueState.ALL).list()) {
             log.debug("Found pull request: {}", ghPullRequest.getNumber());
             pullRequests.add(cacheEndpoint.findOrCreatePullRequest(ghPullRequest));
         }


### PR DESCRIPTION
By default, only open PullRequests are retrieved by the API, but usually one wants to get  ALL into the jQA DB.

I also dropped the branch from the PR retrieval as it does not make sense by my understanding.
Perhaps @StephanPirnbaum as the main author has some background why it was initially added?